### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/src/database/models/Guild.js
+++ b/src/database/models/Guild.js
@@ -335,6 +335,10 @@ function deepMerge(target, source) {
   
   // For each property in source
   for (const key in source) {
+    // Skip prototype pollution properties
+    if (key === '__proto__' || key === 'constructor') {
+      continue;
+    }
     // If source property is an object (and not null or array)
     if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
       // Make sure target property is an object we can merge into


### PR DESCRIPTION
Potential fix for [https://github.com/palidintheonly/MonkeyServerLogger/security/code-scanning/1](https://github.com/palidintheonly/MonkeyServerLogger/security/code-scanning/1)

To fix the problem, we need to modify the `deepMerge` function to prevent prototype pollution. This can be achieved by blocking the `__proto__` and `constructor` properties from being merged or assigned to. We will add a check to skip these properties during the merge process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
